### PR TITLE
Updates first bash script to reference LINGVO_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the following commands should give you a working shell with Lingvo installed.
 ```shell
 LINGVO_DIR="/tmp/lingvo"  # (change to the cloned lingvo directory, e.g. "$HOME/lingvo")
 LINGVO_DEVICE="gpu"  # (Leave empty to build and run CPU only docker)
-sudo docker build --tag tensorflow:lingvo $(test "$LINGVO_DEVICE" = "gpu" && echo "--build-arg base_image=nvidia/cuda:10.0-cudnn7-runtime-ubuntu16.04") - < lingvo/docker/dev.dockerfile
+sudo docker build --tag tensorflow:lingvo $(test "$LINGVO_DEVICE" = "gpu" && echo "--build-arg base_image=nvidia/cuda:10.0-cudnn7-runtime-ubuntu16.04") - < ${LINGVO_DIR}/docker/dev.dockerfile
 sudo docker run --rm $(test "$LINGVO_DEVICE" = "gpu" && echo "--runtime=nvidia") -it -v ${LINGVO_DIR}:/tmp/lingvo -v ${HOME}/.gitconfig:/home/${USER}/.gitconfig:ro -p 6006:6006 -p 8888:8888 --name lingvo tensorflow:lingvo bash
 bazel test -c opt //lingvo:trainer_test //lingvo:models_test
 ```


### PR DESCRIPTION
This change modifies the initial example bash script in the README

Initial example bash script to run in docker references 
```< lingvo/docker/dev.dockerfile``` 

... and should instead reference the previously established variable 
```< ${LINGVO_DIR}/docker/dev.dockerfile```