### PR TITLE
Fix octal constants so they work in all versions of Python

### DIFF
--- a/docker/run_distributed.py
+++ b/docker/run_distributed.py
@@ -152,12 +152,12 @@ def Cleanup():
 
 
 def InitFiles():
-  os.mkdir(SHARED_FS_MOUNTPOINT, 01777)
+  os.mkdir(SHARED_FS_MOUNTPOINT, 0o1777)
   # Create these directories so that we own them, not root.
-  os.mkdir(SHARED_FS_MOUNTPOINT + "/log", 01777)
-  os.mkdir(SHARED_FS_MOUNTPOINT + "/log/train", 01777)
-  os.mkdir(SHARED_FS_MOUNTPOINT + "/log/decoder_test", 01777)
-  os.mkdir(SHARED_FS_MOUNTPOINT + "/log/eval_test", 01777)
+  os.mkdir(SHARED_FS_MOUNTPOINT + "/log", 0o1777)
+  os.mkdir(SHARED_FS_MOUNTPOINT + "/log/train", 0o1777)
+  os.mkdir(SHARED_FS_MOUNTPOINT + "/log/decoder_test", 0o1777)
+  os.mkdir(SHARED_FS_MOUNTPOINT + "/log/eval_test", 0o1777)
 
 
 def InitNetwork():


### PR DESCRIPTION
__01777__ is a syntax error in Python 3 but __0o1777__ works as expected in both Python 2 and Python 3.