### PR TITLE
Change xrange() --> six.moves.xrange() for Python 3

### DIFF
--- a/lingvo/core/layers_with_gpipe.py
+++ b/lingvo/core/layers_with_gpipe.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 from tensorflow.contrib.tpu.python.tpu import tpu_function

--- a/lingvo/core/rnn_layers.py
+++ b/lingvo/core/rnn_layers.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import math
-from six.moves import range
+from six.moves import xrange  # pylint: disable=redefined-builtin
 from six.moves import zip
 import tensorflow as tf
 

--- a/lingvo/tools/wpm_encode_file.py
+++ b/lingvo/tools/wpm_encode_file.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six import text_type
+
 import numpy as np
 
 import tensorflow as tf
@@ -87,11 +89,9 @@ def _MakeTfExample(enc, src_i, src_s, tgt_i, tgt_s):
 
 
 def _Preprocess(text):
-  if not isinstance(text, unicode):
+  if not isinstance(text, text_type):
     text = text.decode('utf-8')
-  text = text.strip()
-  text = text.replace(' </s>', '')
-  return text
+  return text.strip().replace(' </s>', '')
 
 
 def _RunEncoding():

--- a/lingvo/tools/wpm_encode_file.py
+++ b/lingvo/tools/wpm_encode_file.py
@@ -18,10 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from six import text_type
-
 import numpy as np
-
+from six import text_type
 import tensorflow as tf
 
 from lingvo.core import wpm_encoder

--- a/lingvo/trainer.py
+++ b/lingvo/trainer.py
@@ -39,7 +39,8 @@ import time
 
 import numpy as np
 import six
-from six.moves import xrange, zip  # pylint: disable=redefined-builtin
+from six.moves import xrange  # pylint: disable=redefined-builtin
+from six.moves import zip
 import tensorflow as tf
 
 from lingvo import base_runner

--- a/lingvo/trainer.py
+++ b/lingvo/trainer.py
@@ -39,7 +39,7 @@ import time
 
 import numpy as np
 import six
-from six.moves import zip
+from six.moves import xrange, zip  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 from lingvo import base_runner


### PR DESCRIPTION
Also, in _lingvo/tools/wpm_encode_file.py_ change __unicode__ --> __six.text_type__.

[flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/lingvo on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lingvo/trainer.py:691:22: F821 undefined name 'xrange'
      for replica in xrange(device_assignment.num_replicas):
                     ^
./lingvo/trainer.py:692:21: F821 undefined name 'xrange'
        for core in xrange(device_assignment.num_cores_per_replica):
                    ^
./lingvo/core/layers_with_gpipe.py:236:18: F821 undefined name 'xrange'
    for split in xrange(p.num_splits):
                 ^
./lingvo/core/layers_with_gpipe.py:237:23: F821 undefined name 'xrange'
      for layer_id in xrange(layers_per_split):
                      ^
./lingvo/core/layers_with_gpipe.py:251:18: F821 undefined name 'xrange'
    for split in xrange(p.num_splits):
                 ^
./lingvo/core/layers_with_gpipe.py:252:23: F821 undefined name 'xrange'
      for layer_id in xrange(layers_per_split):
                      ^
./lingvo/core/rnn_layers.py:172:20: F821 undefined name 'xrange'
        sequence = xrange(sequence_length - 1, -1, -1)
                   ^
./lingvo/core/rnn_layers.py:174:20: F821 undefined name 'xrange'
        sequence = xrange(0, sequence_length, 1)
                   ^
./lingvo/core/lr_schedule.py:302:43: F821 undefined name 'p'
                              tf.to_float(p.decay_end))
                                          ^
./lingvo/tools/wpm_encode_file.py:90:27: F821 undefined name 'unicode'
  if not isinstance(text, unicode):
                          ^
10    F821 undefined name 'xrange'
10
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
