### PR TITLE
use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/lingvo/core/layers.py
+++ b/lingvo/core/layers.py
@@ -2152,7 +2152,7 @@ class SimpleFullSoftmax(SoftmaxLayer):
       class_ids = py_utils.HasShape(class_ids, [-1, 1])
       per_example_xent, per_example_argmax = self._XentLossByChunk(
           theta, inputs, class_ids)
-    elif p.num_sampled is 0 or p.is_eval:
+    elif p.num_sampled == 0 or p.is_eval:
       assert class_ids is not None
       assert logits is not None
       tf.logging.vlog(

--- a/lingvo/core/layers_test.py
+++ b/lingvo/core/layers_test.py
@@ -2199,7 +2199,7 @@ class SoftmaxLayerTest(tf.test.TestCase):
         # Turn on sampled soft-max; the asserts need to hold for it to be used.
         params.num_sampled = num_samples
         assert class_probabilities is None
-        assert chunk_size is 0
+        assert chunk_size == 0
         assert params.is_eval is not True
 
       params.vn.global_vn = False


### PR DESCRIPTION
Last night I had pizza in https://www.google.com/maps/place/Livigno and thought of this project.

[flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/lingvo on Python 3.7.1

$ flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
```
./lingvo/core/layers.py:2155:10: F632 use ==/!= to compare str, bytes, and int literals
    elif p.num_sampled is 0 or p.is_eval:
         ^
./lingvo/core/layers_test.py:2202:16: F632 use ==/!= to compare str, bytes, and int literals
        assert chunk_size is 0
               ^
2     F632 use ==/!= to compare str, bytes, and int literals
2
```