### PR TITLE
remove the obsolete TODO comment

### DIFF
--- a/lingvo/core/base_input_generator.py
+++ b/lingvo/core/base_input_generator.py
@@ -784,7 +784,6 @@ class BaseInputGeneratorFromFiles(BaseInputGenerator):
     assert not (p.file_pattern and p.file_datasource
                ), 'Only one of file_pattern and data_source can be specified'
 
-    # TODO(b/139345706) remove support for file_pattern
     if not p.file_datasource:
       p.file_datasource = FilePatternToDataSource(p)
     self.CreateChild('datasource', p.file_datasource)


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comment. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lingvo/core/base_input_generator.py (line:787)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: 
https://github.com/tensorflow/lingvo/commit/18ce2b7a38278d0c8d10045234076a52bf51b9e9