### PR TITLE
Add missing dirmngr dependency

### DIFF
--- a/docker/lib.dockerfile
+++ b/docker/lib.dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         sox \
         unzip \
         vim \
+        dirmngr \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
dirmngr is missing and without it the `RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776` step fails with following error:

```
Step 9/19 : RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776
 ---> Running in c2bee2c8416b
Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.wiAempXY5h/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776
gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory
gpg: connecting dirmngr at '/tmp/apt-key-gpghome.wiAempXY5h/S.dirmngr' failed: No such file or directory
gpg: keyserver receive failed: No dirmngr
The command '/bin/sh -c apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776' returned a non-zero code: 2
```

Command used to build the docker image:
`docker build --tag tensorflow:lingvo_lib - < docker/lib.dockerfile`