### PR TITLE
Add missing comma to setup.py

### DIFF
--- a/pip_package/setup.py
+++ b/pip_package/setup.py
@@ -43,7 +43,7 @@ REQUIRED_PACKAGES = [
     'protobuf>=3.8,<4',
     'sklearn',
     'sympy',
-    'tensorflow-datasets'
+    'tensorflow-datasets',
     'tensorflow-gpu==' + tf.__version__,
     'tensorflow-hub',
     'tensorflow-text',


### PR DESCRIPTION
There is a missing comma in `setup.py`. Because of that python concatenates the two lines resulting in a dependency of `tensorflow-datasetstensorflow-gpu==2.4.1` which of course can't be met.