### PR TITLE
fix: typo grammar

### DIFF
--- a/lingvo/core/base_layer.py
+++ b/lingvo/core/base_layer.py
@@ -957,7 +957,7 @@ class BaseLayer(tf.Module, metaclass=BaseLayerMeta):
     need to be created inside of a specific context manager.
 
     There are a few cases of this in the codebase marked as for backwards
-    compability. This is only to ensure that variable scopes remain compatible
+    compatibility. This is only to ensure that variable scopes remain compatible
     through the code migration. New layers should not copy that pattern, and
     instead follow the standard pattern of self.CreateChild() in __init__() and
     self.CreateVariable() in _CreateLayerVariables(). If you are okay with

--- a/lingvo/core/base_model.py
+++ b/lingvo/core/base_model.py
@@ -219,13 +219,13 @@ class BaseTask(base_layer.BaseLayer):
     tp.Define(
         'clip_gradient_norm_to_value', 0.0,
         'Clip gradient by global norm to this value. This is similar to '
-        'the bahaviour of tf.clip_by_global_norm, if you are looking for '
+        'the behaviour of tf.clip_by_global_norm, if you are looking for '
         'tf.clip_by_norm refer to clip_gradient_single_norm_to_value. Note '
         'these are mutually exclusive.')
     tp.Define(
         'clip_gradient_single_norm_to_value', 0.0,
         'Clip gradient by single tensor norm to this value. This is '
-        'similar to the bahaviour of tf.clip_by_norm. Note this is mutually '
+        'similar to the behaviour of tf.clip_by_norm. Note this is mutually '
         'exlusive to using clip_gradient_norm_to_value.')
     tp.Define('grad_norm_to_clip_to_zero', 0.0,
               'Clip gradient to 0 if its norm exceeds this value.')

--- a/lingvo/core/batch_major_attention.py
+++ b/lingvo/core/batch_major_attention.py
@@ -2702,7 +2702,7 @@ class RoutingAttention(MultiHeadedAttention):
 
   This is used in the routing transformer https://arxiv.org/pdf/2003.05997.
 
-  This verison of multi-headed attention differs from the full attention
+  This version of multi-headed attention differs from the full attention
   in that it uses k-means clusterting to cluster the queries and keys first,
   and each query only attend to a subset of keys that are close to the centroid
   closest to that query. As Euclidean distance is used to determine closeness,

--- a/lingvo/core/gshard_layers.py
+++ b/lingvo/core/gshard_layers.py
@@ -1021,7 +1021,7 @@ class StateLayer(base_layer.BaseLayer):
     theta.state:  a tensor of shape `[batch, max_steps, ...]`.
     x:            a tensor of shape `[batch, 1, ...]`.
 
-  Subclass must define the folllowing functions:
+  Subclass must define the following functions:
     NewState(self, shape)
     _Step(theta, x).
 

--- a/lingvo/core/hyperparams.py
+++ b/lingvo/core/hyperparams.py
@@ -465,7 +465,7 @@ class Params:
       if isinstance(val, Params):
         param_pb.param_val.CopyFrom(_ToParam(val, prefix=key))
       elif isinstance(val, list) or isinstance(val, range):
-        # The range function is serialized by explicitely calling it.
+        # The range function is serialized by explicitly calling it.
         param_pb.list_val.items.extend(
             [_ToParamValue(f'{key}[{i}]', v) for i, v in enumerate(val)])
       elif isinstance(val, tuple):

--- a/lingvo/core/layers.py
+++ b/lingvo/core/layers.py
@@ -1249,7 +1249,7 @@ class ProjectionLayer(quant_utils.QuantizableLayer):
       out = self.FromAqtMatmul('w', out)
     else:
       x = tf.reshape(inputs, py_utils.ToStaticShape([-1, p.input_dim]))
-      # TODO(shivaniagrawal): There are the following dimmensions: bn, nmk, the
+      # TODO(shivaniagrawal): There are the following dimensions: bn, nmk, the
       # the correct thing to do here might be scaling on every m and every k,
       # while we are doing every k only.
       x, w = self.ToAqtInputs('w', act=x, weight=w, w_feature_axis=-1)
@@ -2750,7 +2750,7 @@ class PositionalEmbeddingLayer(base_layer.BaseLayer):
     memory inputs to attention.
 
     The use of relative position is possible because sin(x+y) and cos(x+y) can
-    be experessed in terms of y, sin(x) and cos(x).
+    be expressed in terms of y, sin(x) and cos(x).
 
     In particular, we use a geometric sequence of timescales starting with
     min_timescale and ending with max_timescale.  The number of different

--- a/lingvo/core/learner.py
+++ b/lingvo/core/learner.py
@@ -66,7 +66,7 @@ class Learner(base_layer.BaseLayer):
     p.Define(
         'clip_gradient_single_norm_to_value', 0.0,
         'Clip gradient by single tensor norm to this value. This is '
-        'similar to the bahaviour of tf.clip_by_norm. Note this is mutually '
+        'similar to the behaviour of tf.clip_by_norm. Note this is mutually '
         'exlusive to using clip_gradient_norm_to_value.')
     p.Define('grad_norm_to_clip_to_zero', 0.0,
              'Clip gradient to 0 if its norm exceeds this value.')

--- a/lingvo/core/plot.py
+++ b/lingvo/core/plot.py
@@ -209,7 +209,7 @@ class MatplotlibFigureSummary:
         independently on each element of the batch.  Overrides plot_func passed
         in to the constructor.
       **kwargs: A dict of additional non-tensor keyword args to pass to
-        plot_func when generating the plot, overridding any
+        plot_func when generating the plot, overriding any
         shared_subplot_kwargs.  Useful for e.g. specifying a subplot's title.
     """
     merged_kwargs = dict(self._shared_subplot_kwargs, **kwargs)

--- a/lingvo/core/py_utils.py
+++ b/lingvo/core/py_utils.py
@@ -4298,7 +4298,7 @@ def MixByWeight(inputs, weights, seed=None):
     seed: random seed.
 
   Returns:
-    A probablistic sample from the inputs proportional to the weights. The
+    A probabilistic sample from the inputs proportional to the weights. The
     return type will be the same as return type of individual 'fn' from the
     inputs.
     A one-hot vector of the source selected.

--- a/lingvo/core/rnn_cell.py
+++ b/lingvo/core/rnn_cell.py
@@ -1353,7 +1353,7 @@ class WeightNormalizedLSTMCellSimple(LSTMCellSimple):
 
 
 class NormalizedLSTMCellSimple(LSTMCellSimple):
-  """LSTM Cell that allows customzied normalization.
+  """LSTM Cell that allows customized normalization.
 
   theta:
 

--- a/lingvo/core/rnn_layers.py
+++ b/lingvo/core/rnn_layers.py
@@ -195,7 +195,7 @@ class StackedRNNBase(base_layer.BaseLayer):
 
 
 class StackedFRNNLayerByLayer(StackedRNNBase, quant_utils.QuantizableLayer):
-  """An implemention of StackedRNNBase which computes layer-by-layer."""
+  """An implementation of StackedRNNBase which computes layer-by-layer."""
 
   @classmethod
   def Params(cls):
@@ -296,7 +296,7 @@ class StackedFRNNLayerByLayer(StackedRNNBase, quant_utils.QuantizableLayer):
 
 
 class StackedBiFRNNLayerByLayer(StackedRNNBase, quant_utils.QuantizableLayer):
-  """An implemention of StackedRNNBase with bidirection RNN layers."""
+  """An implementation of StackedRNNBase with bidirection RNN layers."""
 
   @classmethod
   def Params(cls):

--- a/lingvo/core/saver.py
+++ b/lingvo/core/saver.py
@@ -174,7 +174,7 @@ class Saver:
         # the latest checkpoint before raise the error.
         msg = "Checkpoint sanity check failed: {} {} {}\n".format(
             prefix, ",".join([_VarKey(v) for v in variables]), rule)
-        # Also saves the error messge into a file.
+        # Also saves the error message into a file.
         file_io.write_string_to_file("{}.failed".format(prefix), msg)
         raise tf.errors.AbortedError(None, None, msg)
 
@@ -182,7 +182,7 @@ class Saver:
     """Generate a new checkpoint.
 
     Args:
-      sess: A session with tf.Graph under which this object is constructred.
+      sess: A session with tf.Graph under which this object is constructed.
 
     Returns:
       If the checkpoint is successfully generated, returns its global step
@@ -250,7 +250,7 @@ class Saver:
     """Restore variables from a checkpoint.
 
     Args:
-      sess: A session with tf.Graph under which this object is constructred.
+      sess: A session with tf.Graph under which this object is constructed.
       checkpoint_id: If None, restore from the latest checkpoint. Otherwise,
         restore from the specific checkpoint.
 

--- a/lingvo/tasks/asr/decoder.py
+++ b/lingvo/tasks/asr/decoder.py
@@ -264,7 +264,7 @@ class AsrDecoderBase(base_decoder.BaseBeamSearchDecoder):
     p.Define('focal_loss_alpha', None, 'The weighting factor alpha.')
     p.Define('focal_loss_gamma', None, 'Tunable focusing parameter.')
     p.Define('adapter_layer_tpl', layers.MultitaskAdapterLayer.Params(),
-             'Params for domain/language adatper layer.')
+             'Params for domain/language adapter layer.')
     p.Define(
         'adapter_task_id_field', None,
         'Setting this will enable the use of adapter layers. This is the name '

--- a/lingvo/tasks/car/ap_metric.py
+++ b/lingvo/tasks/car/ap_metric.py
@@ -349,7 +349,7 @@ class APMetrics(BaseMetric):
       dimension, 0 indexes precision and 1 indexes recall.
       - calibrations: A list of C dicts mapping metrics names to np.float32
       arrays of shape [number of predictions, 2]. The first column is the
-      predicted probabilty and the second column is 0 or 1 indicating that the
+      predicted probability and the second column is 0 or 1 indicating that the
       prediction matched a ground truth item.
     """
     raise NotImplementedError('_ComputeFinalMetric must be implemented')

--- a/lingvo/tasks/car/calibration_processing.py
+++ b/lingvo/tasks/car/calibration_processing.py
@@ -133,8 +133,8 @@ class CalibrationCalculator:
         indexes precision and 1 indexes recall.
       - calibrations: A list of C dicts mapping metrics names to np.float32
         arrays of shape [number of predictions, 2]. The first column is the
-        predicted probability and the second column is 0 or 1 indicating that the
-        prediction matched a ground truth item.
+        predicted probability and the second column is 0 or 1 indicating that
+        the prediction matched a ground truth item.
 
     Returns:
       nothing

--- a/lingvo/tasks/car/calibration_processing.py
+++ b/lingvo/tasks/car/calibration_processing.py
@@ -133,7 +133,7 @@ class CalibrationCalculator:
         indexes precision and 1 indexes recall.
       - calibrations: A list of C dicts mapping metrics names to np.float32
         arrays of shape [number of predictions, 2]. The first column is the
-        predicted probabilty and the second column is 0 or 1 indicating that the
+        predicted probability and the second column is 0 or 1 indicating that the
         prediction matched a ground truth item.
 
     Returns:

--- a/lingvo/tasks/car/geometry.py
+++ b/lingvo/tasks/car/geometry.py
@@ -126,7 +126,7 @@ def CoordinateTransform(points, pose):
   Args:
     points: Float shape [..., 3]: Points to transform to new coordinates.
     pose: Float shape [6]: [translate_x, translate_y, translate_z, yaw, roll,
-      pitch]. The pose in the frame that 'points' comes from, and the defintion
+      pitch]. The pose in the frame that 'points' comes from, and the definition
       of the rotation and translation angles to apply to points.
 
   Returns:

--- a/lingvo/tasks/car/kitti_ap_metric.py
+++ b/lingvo/tasks/car/kitti_ap_metric.py
@@ -220,7 +220,7 @@ class KITTIAPMetrics(ap_metric.APMetrics):
       dimension, 0 indexes precision and 1 indexes recall.
       - calibrations: A list of C dicts mapping metrics names to np.float32
       arrays of shape [number of predictions, 2]. The first column is the
-      predicted probabilty and the second column is 0 or 1 indicating that the
+      predicted probability and the second column is 0 or 1 indicating that the
       prediction matched a ground truth item.
     """
     tf.logging.info('Computing final KITTI metrics.')

--- a/lingvo/tasks/car/pointnet.py
+++ b/lingvo/tasks/car/pointnet.py
@@ -119,7 +119,7 @@ class PointNet(builder_lib.ModelBuilderBase):
     return p
 
   def Segmentation(self, name='pointnet_segmentation'):
-    """PointNet archetecture for segmentation."""
+    """PointNet architecture for segmentation."""
     # dropout is NOT used in the vanilla setting from the paper.
     # pyformat: disable
     main_tower = self._Seq(


### PR DESCRIPTION
## description
fix typo on separate file and replace to correct words with reference from [merriam webster](merriam-webster.com)

## testing
testing not include because just fix the typo and replace the correct one