### PR TITLE
Fixes the "name 'py_proto_library' is not defined" error.

### DIFF
--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -75,7 +75,6 @@ ARG pip_dependencies=' \
       attrs \
       contextlib2 \
       dataclasses \
-      flax \
       google-api-python-client \
       graph-compression-google-research \
       h5py \

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -75,6 +75,7 @@ ARG pip_dependencies=' \
       attrs \
       contextlib2 \
       dataclasses \
+      flax \
       google-api-python-client \
       graph-compression-google-research \
       h5py \

--- a/lingvo/jax/BUILD
+++ b/lingvo/jax/BUILD
@@ -1,7 +1,7 @@
 # Description:
 #   Base directory for the lingvo Jax library.
 
-load("//lingvo:lingvo.bzl", "pytype_strict_binary", "pytype_strict_library")
+load("//lingvo:lingvo.bzl", "pytype_strict_binary", "pytype_strict_library", "lingvo_proto_py")
 load("//lingvo:lingvo.bzl", "py_strict_test")
 load("//lingvo/jax:build-visibility.bzl", "JAX_VISIBILITY")
 
@@ -598,8 +598,8 @@ proto_library(
     srcs = ["checkpoint.proto"],
 )
 
-py_proto_library(
+lingvo_proto_py(
     name = "checkpoint_py_pb2",
-    api_version = 2,
+    src = "checkpoint.proto",
     deps = [":checkpoint_proto"],
 )

--- a/lingvo/jax/BUILD
+++ b/lingvo/jax/BUILD
@@ -1,8 +1,9 @@
 # Description:
 #   Base directory for the lingvo Jax library.
 
-load("//lingvo:lingvo.bzl", "pytype_strict_binary", "pytype_strict_library", "lingvo_proto_py")
+load("//lingvo:lingvo.bzl", "pytype_strict_binary", "pytype_strict_library")
 load("//lingvo:lingvo.bzl", "py_strict_test")
+load("//lingvo:lingvo.bzl", "lingvo_proto_py")
 load("//lingvo/jax:build-visibility.bzl", "JAX_VISIBILITY")
 
 package(default_visibility = JAX_VISIBILITY)


### PR DESCRIPTION
Background: https://github.com/tensorflow/lingvo/issues/274#issuecomment-1071115444.

Also adds 'flax' as a pip dependency. Background: https://github.com/tensorflow/lingvo/issues/275.