### PR TITLE
Enable Aarch64 builds of Lingvo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,9 +5,9 @@ load("//lingvo:repo.bzl", "cc_tf_configure", "icu", "lingvo_protoc_deps", "lingv
 
 http_archive(
     name = "org_tensorflow",
-    strip_prefix = "tensorflow-2.10.0",
-    sha256 = "d79a95ede8305f14a10dd0409a1e5a228849039c19ccfb90dfe8367295fd04e0",
-    urls = ["https://github.com/tensorflow/tensorflow/archive/v2.10.0.zip"],
+    strip_prefix = "tensorflow-2.13.0",
+    sha256 = "447cdb65c80c86d6c6cf1388684f157612392723eaea832e6392d219098b49de",
+    urls = ["https://github.com/tensorflow/tensorflow/archive/v2.13.0.zip"],
 )
 
 # This import (along with the org_tensorflow archive) is necessary to provide the devtoolset-9 toolchain

--- a/lingvo/lingvo.bzl
+++ b/lingvo/lingvo.bzl
@@ -2,7 +2,7 @@
 
 def tf_copts():
     # TODO(drpng): autoconf this.
-    return ["-D_GLIBCXX_USE_CXX11_ABI=1", "-std=c++14", "-Wno-sign-compare", "-mavx"] + select({
+    return ["-D_GLIBCXX_USE_CXX11_ABI=1", "-std=c++17", "-Wno-sign-compare"] + select({
         "//lingvo:cuda": ["-DGOOGLE_CUDA=1"],
         "//conditions:default": [],
     })

--- a/lingvo/repo.bzl
+++ b/lingvo/repo.bzl
@@ -170,12 +170,14 @@ def cc_tf_configure():
     make_tflib_repo(name = "tensorflow_solib")
 
 def lingvo_testonly_deps():
+    BM_COMMIT = "f7547e29ccaed7b64ef4f7495ecfff1c9f6f3d03"
+    BM_SHA256 = "552ca3d4d1af4beeb1907980f7096315aa24150d6baf5ac1e5ad90f04846c670"
     http_archive(
         name = "com_google_benchmark",
-        sha256 = "23082937d1663a53b90cb5b61df4bcc312f6dee7018da78ba00dd6bd669dfef2",
-        strip_prefix = "benchmark-1.5.1",
+        sha256 = BM_SHA256,
+        strip_prefix = "benchmark-{commit}".format(commit = BM_COMMIT),
         urls = [
-            "https://github.com/google/benchmark/archive/v1.5.1.tar.gz",
+            "https://github.com/google/benchmark/archive/{commit}.tar.gz".format(commit = BM_COMMIT),
         ],
     )
 
@@ -232,9 +234,9 @@ filegroup(
 )
 """,
         urls = [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.2/protoc-3.9.2-linux-x86_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-aarch_64.zip"
         ],
-        sha256 = "0d9034a3b02bd77edf5ef926fb514819a0007f84252c5e6a6391ddfc4189b904",
+        sha256 = "a584286dfa8ebb17032ece206ed74d5e9931e2edb9016e427be2a0dab3b21071"
     )
 
 def icu():

--- a/pip_package/build.sh
+++ b/pip_package/build.sh
@@ -30,7 +30,7 @@ set -e -x
 # Override the following env variables if necessary.
 export PYTHON_MINOR_VERSION="${PYTHON_MINOR_VERSION?python minor version required}"
 PYTHON="python3.${PYTHON_MINOR_VERSION}"
-update-alternatives --install /usr/bin/python3 python3 "/usr/bin/$PYTHON" 1
+#update-alternatives --install /usr/bin/python3 python3 "/usr/bin/$PYTHON" 1
 
 function write_to_bazelrc() {
   echo "$1" >> .bazelrc
@@ -44,7 +44,7 @@ function write_action_env_to_bazelrc() {
 [ -e .bazelrc ] && rm .bazelrc
 
 write_to_bazelrc "build -c opt"
-write_to_bazelrc 'build --copt=-mavx --host_copt=-mavx'
+#write_to_bazelrc 'build --copt=-mavx --host_copt=-mavx'
 write_to_bazelrc 'build --auto_output_filter=subpackages'
 write_to_bazelrc 'build --copt="-Wall" --copt="-Wno-sign-compare"'
 write_to_bazelrc 'build --linkopt="-lrt -lm"'
@@ -97,7 +97,7 @@ DST_DIR="/tmp/lingvo/dist"
 # Note: constraining our release to plat==manylinux2014_x86_64 to match TF.
 # This corresponds to our use of the devtoolset-9 toolchain.
 find "$DST_DIR" -name "*cp3${PYTHON_MINOR_VERSION}*.whl" |\
-  xargs -n1 ./third_party/auditwheel.sh repair --plat manylinux2014_x86_64 -w "$DST_DIR"
+  xargs -n1 ./third_party/auditwheel.sh repair --plat linux_aarch64 -w "$DST_DIR"
 
 rm .bazelrc
 

--- a/pip_package/invoke_build_per_interpreter.sh
+++ b/pip_package/invoke_build_per_interpreter.sh
@@ -18,11 +18,4 @@
 #  'auditwheel repair requires patchelf >= 0.14'
 pip install patchelf
 
-PYTHON_MINOR_VERSION=10 pip_package/build.sh \
-	--crosstool_top=@sigbuild-r2.9-python3.10_config_cuda//crosstool:toolchain
-
-PYTHON_MINOR_VERSION=9 pip_package/build.sh \
-	--crosstool_top=@sigbuild-r2.9-python3.9_config_cuda//crosstool:toolchain
-
-PYTHON_MINOR_VERSION=8 pip_package/build.sh \
-	--crosstool_top=@sigbuild-r2.9-python3.8_config_cuda//crosstool:toolchain
+PYTHON_MINOR_VERSION=10 pip_package/build.sh 

--- a/pip_package/setup.py
+++ b/pip_package/setup.py
@@ -44,8 +44,8 @@ REQUIRED_PACKAGES = [
     'sympy',
     'tensorflow-datasets',
     'tensorflow-hub',
-    'tensorflow-text~=2.9.0',
-    'tensorflow~=2.9.2',
+#    'tensorflow-text~=2.9.0',
+#    'tensorflow~=2.9.2',
 ]
 
 

--- a/third_party/auditwheel.sh
+++ b/third_party/auditwheel.sh
@@ -16,7 +16,7 @@
 
 TF_SHARED_LIBRARY_NAME=$(grep -r TF_SHARED_LIBRARY_NAME .bazelrc | awk -F= '{print$2}')
 
-POLICY_JSON=$(find / -name manylinux-policy.json)
+POLICY_JSON=$(find / -name manylinux-policy.json 2>/dev/null)
 
 sed -i "s/libresolv.so.2\"/libresolv.so.2\", $TF_SHARED_LIBRARY_NAME/g" $POLICY_JSON
 


### PR DESCRIPTION
I don't expect this to be merged as-is, but it can be used as a reference of an ARM64 build of Lingvo that is good enough to unblock PAXML running.